### PR TITLE
Add file system sink.

### DIFF
--- a/docker/ops-playground-image/java/flink-playground-clickcountjob/src/main/java/org/apache/flink/playgrounds/ops/clickcount/records/ClickEvent.java
+++ b/docker/ops-playground-image/java/flink-playground-clickcountjob/src/main/java/org/apache/flink/playgrounds/ops/clickcount/records/ClickEvent.java
@@ -41,6 +41,13 @@ public class ClickEvent {
 		this.page = page;
 	}
 
+	public String buildFileSystemString() {
+		final StringBuilder sb = new StringBuilder();
+		sb.append(timestamp).append("\t");
+		sb.append(page);
+		return sb.toString();
+	}
+
 	public Date getTimestamp() {
 		return timestamp;
 	}

--- a/docker/ops-playground-image/java/flink-playground-clickcountjob/src/main/java/org/apache/flink/playgrounds/ops/clickcount/sinks/FileSink.java
+++ b/docker/ops-playground-image/java/flink-playground-clickcountjob/src/main/java/org/apache/flink/playgrounds/ops/clickcount/sinks/FileSink.java
@@ -1,0 +1,20 @@
+package org.apache.flink.playgrounds.ops.clickcount.sinks;
+
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.DateTimeBucketAssigner;
+
+public class FileSink {
+    private FileSink() {}
+
+    public static StreamingFileSink<String> buildSink(String outputPath, String bucketingPeriod) {
+
+        StreamingFileSink<String> fileSink = StreamingFileSink
+            .forRowFormat(new Path(outputPath), new SimpleStringEncoder<String>("UTF-8"))
+            .withBucketAssigner(new DateTimeBucketAssigner(bucketingPeriod))
+            .build();
+
+        return fileSink;
+    }
+}

--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -54,6 +54,7 @@ services:
       - ./conf:/opt/flink/conf
       - /tmp/flink-checkpoints-directory:/tmp/flink-checkpoints-directory
       - /tmp/flink-savepoints-directory:/tmp/flink-savepoints-directory
+      - /tmp/filesink-directory:/tmp/filesink-directory
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   zookeeper:


### PR DESCRIPTION
Closes #3 

```
➜  operations-playground git:(add-file-system-sink-to-save-click-data) ✗ head /tmp/filesink-directory/2021-02-20--04-19/part-0-13
Thu Jan 01 00:10:47 UTC 1970    /jobs
Thu Jan 01 00:10:47 UTC 1970    /about
Thu Jan 01 00:10:47 UTC 1970    /news
Thu Jan 01 00:10:47 UTC 1970    /help
Thu Jan 01 00:10:47 UTC 1970    /index
Thu Jan 01 00:10:47 UTC 1970    /shop
Thu Jan 01 00:10:47 UTC 1970    /jobs
Thu Jan 01 00:10:47 UTC 1970    /about
Thu Jan 01 00:10:47 UTC 1970    /news
Thu Jan 01 00:10:47 UTC 1970    /help
➜  operations-playground git:(add-file-system-sink-to-save-click-data) ✗
```